### PR TITLE
Improve time series model notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Este proyecto analiza datos históricos y actuales de la calidad del aire en Pue
 
 ## Uso
 
-- **Notebooks:** Ejecuta los notebooks en `notebooks/` para análisis exploratorio, limpieza y modelado. El cuaderno `04_series_temporales.ipynb` ejemplifica la carga de datos históricos y un modelo ARIMA básico para pronosticar contaminantes.
+ - **Notebooks:** Ejecuta los notebooks en `notebooks/` para análisis exploratorio, limpieza y modelado. El cuaderno `04_series_temporales.ipynb` ilustra la carga de datos históricos, pruebas de estacionariedad y un modelo ARIMA entrenado con división en conjuntos de entrenamiento y prueba para pronosticar contaminantes.
 - **App interactiva:**
   ```bash
   cd app

--- a/notebooks/04_series_temporales.ipynb
+++ b/notebooks/04_series_temporales.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# An\u00e1lisis de Series Temporales\n",
+    "# Análisis de Series Temporales\n",
     "\n",
-    "Demostraci\u00f3n de un modelo ARIMA para pronosticar PM10."
+    "Demostración de un modelo ARIMA para pronosticar PM10."
    ]
   },
   {
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Carga y preparaci\u00f3n de datos"
+    "## Carga y preparación de datos"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Modelo ARIMA b\u00e1sico"
+    "## Análisis y prueba de estacionariedad"
    ]
   },
   {
@@ -55,16 +55,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "modelo = ARIMA(serie, order=(1,1,1))\n",
-    "resultado = modelo.fit()\n",
-    "predicciones = resultado.predict(start=serie.index[0], end=serie.index[-1])"
+    "serie.plot(figsize=(12,4))\n",
+    "plt.title('PM10 en el tiempo')\n",
+    "plt.show()\n",
+    "from statsmodels.tsa.stattools import adfuller\n",
+    "adf = adfuller(serie)\n",
+    "print('p-valor ADF:', adf[1])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Comparaci\u00f3n de valores reales vs. estimados"
+    "## Modelo ARIMA y evaluación"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_size = int(len(serie)*0.8)\n",
+    "train, test = serie[:train_size], serie[train_size:]\n",
+    "modelo = ARIMA(train, order=(1,1,1))\n",
+    "resultado = modelo.fit()\n",
+    "predicciones = resultado.predict(start=test.index[0], end=test.index[-1])\n",
+    "from sklearn.metrics import mean_absolute_error\n",
+    "mae = mean_absolute_error(test, predicciones)\n",
+    "print('MAE:', mae)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparación de valores reales vs. estimados"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- extend 04_series_temporales notebook with stationarity analysis, train/test split and model evaluation
- document the enhanced notebook in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428c83e73883259831b5bba5f90985